### PR TITLE
Add: permissions block toe build-and-push workflow

### DIFF
--- a/.github/workflows/build-and-push-containers.yaml
+++ b/.github/workflows/build-and-push-containers.yaml
@@ -12,6 +12,9 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write # Needed for GHCR
     steps:
       - name: Checkout
         uses: actions/checkout@v4 


### PR DESCRIPTION
This permissions are needed for the auto-generated secrets.GITHUB_TOKEN token to have the specified permissions, else, the push to ghcr.io will fail.