### PR TITLE
Add: permissions block to calling job

### DIFF
--- a/.github/workflows/smpl-deploy-staging.yaml
+++ b/.github/workflows/smpl-deploy-staging.yaml
@@ -7,5 +7,8 @@ on:
 
 jobs:
   build-and-push-services:
+    permissions:
+      contents: read
+      packages: write # Needed for GHCR
     name: Build and Push Services
     uses: ./.github/workflows/build-and-push-containers.yaml 


### PR DESCRIPTION
If this permissions block is not add, the embedded job can not request broader (packages: write) permissions than the calling job/workflow.