### PR TITLE
Add: platform argument to docker/build-and-push-action

### DIFF
--- a/.github/workflows/build-and-push-containers.yaml
+++ b/.github/workflows/build-and-push-containers.yaml
@@ -36,5 +36,6 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/orders:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/orders:latest
+          platforms: linux/amd64
 
           


### PR DESCRIPTION
This argument allows us to specify the target platform against which the image is meant to be build/run.