### PR TITLE
Fix: bug in buld-and-push-containers job

### DIFF
--- a/.github/workflows/build-and-push-containers.yaml
+++ b/.github/workflows/build-and-push-containers.yaml
@@ -46,5 +46,5 @@ jobs:
           push: true
           platforms: ${{ inputs.platforms }} 
           tags: |
-            ghcr.io/${{ github.repository_owner }}/orders:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/orders:latest
+            ghcr.io/${{ github.repository_owner }}/${{ inputs.service }}:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ inputs.service }}:latest


### PR DESCRIPTION
The name of the service was hardcoded to 'orders' instead of using the 'inputs.service' variable. This update fixes that issue.